### PR TITLE
Fix fragment similarity function call

### DIFF
--- a/posebench/analysis/inference_analysis.py
+++ b/posebench/analysis/inference_analysis.py
@@ -170,7 +170,7 @@ def select_primary_ligands_in_df(
 
             if select_most_similar_pred_frag:
                 mol_pred_frags = [
-                    find_most_similar_frag(mol_true_frag, mol_pred_frags)[0]
+                    find_most_similar_frag(Chem.Mol(mol_true_frag), mol_pred_frags)[0]
                     for mol_true_frag in mol_true_frags
                 ]
                 if not any(mol_pred_frags):


### PR DESCRIPTION
Pass a copy of the mol_true_frag to find_most_similar_frag function to avoid modifying the original mol_true_frag.

this pull request fixes #20 